### PR TITLE
Stream /servers/[server_slug] layout instead of blocking await

### DIFF
--- a/front-ze/app/servers/[server_slug]/ServerDataProvider.tsx
+++ b/front-ze/app/servers/[server_slug]/ServerDataProvider.tsx
@@ -1,5 +1,6 @@
 'use client'
 import {createContext, ReactNode, use, useContext} from "react";
+import {notFound} from "next/navigation";
 import {Server} from "types/community";
 import {ServerSlugPromise} from "./util.ts";
 
@@ -7,6 +8,7 @@ type ServerData = {server: Server}
 export const ServerDataContext = createContext<ServerData | null>({ server: null });
 export default function ServerDataProvider({slugPromise, children}: {slugPromise: ServerSlugPromise, children: ReactNode}) {
     const server = use(slugPromise)
+    if (!server) throw notFound()
     return <ServerDataContext.Provider value={{ server }}>
         {children}
     </ServerDataContext.Provider>

--- a/front-ze/app/servers/[server_slug]/layout.tsx
+++ b/front-ze/app/servers/[server_slug]/layout.tsx
@@ -4,7 +4,7 @@ import {ReactNode, Suspense} from "react";
 import 'leaflet/dist/leaflet.css';
 import ResponsiveAppSelector from "./ResponsiveAppSelector";
 import Loading from "./loading.tsx";
-import {getServerSlugOrNotFound} from "./util.ts";
+import {getServerSlug} from "./util.ts";
 
 export default async function ServerLayout({
     children,
@@ -14,8 +14,7 @@ export default async function ServerLayout({
     params: Promise<{ server_slug: string }>;
 }) {
     const { server_slug } = await params
-    const server = await getServerSlugOrNotFound(server_slug)
-    const serverPromise = Promise.resolve(server)
+    const serverPromise = getServerSlug(server_slug)
     const user = getServerUser();
 
     return <>


### PR DESCRIPTION
## Summary
- `app/servers/[server_slug]/layout.tsx` used to `await getServerSlugOrNotFound(...)` before rendering anything, blocking the whole route segment (nav bar, footer, players/maps/radar pages) and making the segment's `loading.tsx` dead code, since nothing ever suspended.
- Switched to `getServerSlug` (no await) and pass the raw promise down, matching the streaming pattern already used in `page.tsx`/`ServerContentWrapper.tsx`.
- `ServerDataProvider` (the client-side `use()` consumer) now does the not-found check that the old server-side `getServerSlugOrNotFound` used to do, since the promise it receives can resolve to `null`.

## Test plan
- [x] `tsc --noEmit` — no new errors introduced (remaining errors are pre-existing, unrelated to these files)
- [ ] Manually verify `/servers/<valid-slug>` still renders correctly and the segment's loading skeleton now shows while data is in flight
- [ ] Manually verify `/servers/<bogus-slug>` still renders the not-found page
- [ ] Spot-check a nested route (e.g. `/servers/<slug>/players`) still works via `useServerData()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)