### PR TITLE
Maps page: initial map-list fetch + loading skeletons

### DIFF
--- a/front-ze/app/servers/[server_slug]/maps/MapsSearchIndex.tsx
+++ b/front-ze/app/servers/[server_slug]/maps/MapsSearchIndex.tsx
@@ -1,28 +1,63 @@
 'use client'
 import MapsSearchControls from "components/maps/MapsSearchControls.tsx";
 import MapsFilterTabs, {FilterTypes} from "components/maps/MapsFilterTab.tsx";
-import MapsTable from "components/maps/MapsTable";
-import MapsMobileView from "components/maps/MapsMobileView";
+import MapsTable, {MapsTableSkeleton} from "components/maps/MapsTable";
+import MapsMobileView, {MapsMobileViewSkeleton} from "components/maps/MapsMobileView";
 import LoginDialog from "components/ui/LoginDialog.tsx";
-import {use, useEffect, useState} from "react";
+import {use, useEffect, useRef, useState} from "react";
 import {fetchApiServerUrl, fetchServerUrl} from "utils/generalUtils";
 import {MapPlayedPaginated, ServerMap} from "types/maps.ts";
 import {ServerSlugPromise} from "../util.ts";
 import {SteamProfile} from "../../../../next-auth-steam/steam.ts";
 import {useMapNotifications} from "lib/hooks/useMapNotifications";
+import {Skeleton} from "components/ui/skeleton";
 
 import {useTranslations} from 'next-intl';
 
 export type SortByIndex = "LastPlayed" |  "HighestCumHour" |  "UniquePlayers" |  "FrequentlyPlayed" |  "HighestHour"
 
-export default function MapsSearchIndex({ serverPromise, userPromise }: { serverPromise: ServerSlugPromise, userPromise: Promise<SteamProfile | null> }) {
+export function MapsSearchIndexLoading() {
+    return <>
+        <div className="border border-border rounded-lg bg-card p-6 mb-6">
+            <div className="grid grid-cols-1 md:grid-cols-12 gap-4">
+                <div className="md:col-span-8">
+                    <Skeleton className="h-10 w-full" />
+                </div>
+                <div className="md:col-span-4">
+                    <Skeleton className="h-10 w-full" />
+                </div>
+            </div>
+        </div>
+
+        <div className="border border-border rounded-lg bg-card mb-6 p-3">
+            <div className="flex gap-4 overflow-x-auto">
+                {Array.from({length: 6}).map((_, i) => (
+                    <Skeleton key={i} className="h-6 w-20 flex-shrink-0" />
+                ))}
+            </div>
+        </div>
+
+        <div className="hidden md:block">
+            <MapsTableSkeleton />
+        </div>
+
+        <div className="block md:hidden space-y-4">
+            {Array.from({length: 5}).map((_, i) => (
+                <MapsMobileViewSkeleton key={i} />
+            ))}
+        </div>
+    </>
+}
+
+export default function MapsSearchIndex({ serverPromise, userPromise, initialMapsPromise }: { serverPromise: ServerSlugPromise, userPromise: Promise<SteamProfile | null>, initialMapsPromise: Promise<MapPlayedPaginated> }) {
     const t = useTranslations('maps.searchIndex');
     const server = use(serverPromise)
     const user = use(userPromise)
+    const initialMapsData = use(initialMapsPromise)
     const server_id = server.id;
     const { getSubscriptionType, refresh: refreshNotifications } = useMapNotifications(!!user);
-    const [mapsData, setMapsData] = useState<MapPlayedPaginated | null>(null);
-    const [loading, setLoading] = useState<boolean>(true);
+    const [mapsData, setMapsData] = useState<MapPlayedPaginated | null>(initialMapsData);
+    const [loading, setLoading] = useState<boolean>(false);
     const [, setError] = useState<string | null>(null);
     const [autocompleteOptions, setAutocompleteOptions] = useState<ServerMap[]>([]);
 
@@ -30,10 +65,19 @@ export default function MapsSearchIndex({ serverPromise, userPromise }: { server
     const [searchInput, setSearchInput] = useState<string>('');
     const [sortBy, setSortBy] = useState<SortByIndex>('LastPlayed');
     const [filterTab, setFilterTab] = useState<FilterTypes>('all');
-    const [favorites, setFavorites] = useState<Set<string>>(new Set());
+    const [favorites, setFavorites] = useState<Set<string>>(() => {
+        const favoriteSet = new Set<string>();
+        if (user && initialMapsData?.maps) {
+            initialMapsData.maps.forEach(map => {
+                if (map.is_favorite) favoriteSet.add(map.map);
+            });
+        }
+        return favoriteSet;
+    });
     const [page, setPage] = useState<number>(0);
     const [autocompleteLoading, setAutocompleteLoading] = useState<boolean>(false);
     const [loginDialogOpen, setLoginDialogOpen] = useState<boolean>(false);
+    const isFirstRun = useRef(true);
 
     useEffect(() => {
         if (!searchInput.trim()) {
@@ -77,6 +121,11 @@ export default function MapsSearchIndex({ serverPromise, userPromise }: { server
 
     useEffect(() => {
         if (!server_id) return;
+
+        if (isFirstRun.current) {
+            isFirstRun.current = false;
+            return;
+        }
 
         const loadMaps = async () => {
             try {

--- a/front-ze/app/servers/[server_slug]/maps/page.tsx
+++ b/front-ze/app/servers/[server_slug]/maps/page.tsx
@@ -1,14 +1,14 @@
-import CurrentMatch from "components/maps/CurrentMatch";
+import CurrentMatch, {CurrentMatchLoading} from "components/maps/CurrentMatch";
 import {fetchServerUrl, formatTitle, socialMeta} from "utils/generalUtils";
 import {getServerSlugOrNotFound, threeMinutes} from "../util";
-import MapsSearchIndex from "./MapsSearchIndex";
+import MapsSearchIndex, {MapsSearchIndexLoading} from "./MapsSearchIndex";
 import getServerUser from "../../../getServerUser";
 import {Metadata} from "next";
 import {MapPlayedPaginated} from "types/maps.ts";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import {Suspense} from "react";
-import {getContinentStatsNow, getMatchNow} from "./util.ts";
+import {getContinentStatsNow, getMapsIndexNow, getMatchNow} from "./util.ts";
 import {AdSpot} from "components/ui/AdSpot";
 import { getTranslations } from 'next-intl/server';
 dayjs.extend(relativeTime)
@@ -46,14 +46,15 @@ export default async function Page({ params }){
     const user = getServerUser()
     const matchData = server.then(e => getMatchNow(e.id))
     const playerContinents = server.then(e => getContinentStatsNow(e.id))
+    const initialMapsPromise = server.then(e => getMapsIndexNow(e.id))
 
     return <div className="container max-w-screen-xl py-6 max-sm:px-0.5 mx-auto px-2">
-        <Suspense fallback={null}>
+        <Suspense fallback={<CurrentMatchLoading />}>
             <CurrentMatch serverPromise={server} mapCurrentPromise={matchData} playerContinentsPromise={playerContinents} userPromise={user} />
         </Suspense>
         <AdSpot className="my-4" />
-        <Suspense fallback={null}>
-            <MapsSearchIndex serverPromise={server} userPromise={user} />
+        <Suspense fallback={<MapsSearchIndexLoading />}>
+            <MapsSearchIndex serverPromise={server} userPromise={user} initialMapsPromise={initialMapsPromise} />
         </Suspense>
     </div>
 }

--- a/front-ze/app/servers/[server_slug]/maps/util.ts
+++ b/front-ze/app/servers/[server_slug]/maps/util.ts
@@ -1,5 +1,5 @@
-import {ServerMapMatch} from "types/maps";
-import {fetchServerUrl, fetchUrl} from "utils/generalUtils";
+import {MapPlayedPaginated, ServerMapMatch} from "types/maps";
+import {fetchApiServerUrl, fetchServerUrl, fetchUrl} from "utils/generalUtils";
 import {oneMinute} from "../util.ts";
 import {ContinentStatistics} from "types/players.ts";
 
@@ -10,4 +10,10 @@ export async function getMatchNow(serverId: string): Promise<ServerMapMatch> {
 export async function getContinentStatsNow(serverId: string): Promise<ContinentStatistics> {
     const data = await fetchUrl(`/radars/${serverId}/live_statistics/continents`, { next: {revalidate: oneMinute} })
     return data as ContinentStatistics
+}
+export async function getMapsIndexNow(serverId: string): Promise<MapPlayedPaginated> {
+    const data = await fetchApiServerUrl(serverId, '/maps/last/sessions', {
+        params: { page: 0, sorted_by: 'LastPlayed' },
+    })
+    return data as MapPlayedPaginated
 }

--- a/front-ze/components/maps/CurrentMatch.tsx
+++ b/front-ze/components/maps/CurrentMatch.tsx
@@ -25,6 +25,36 @@ import {useTranslations} from "next-intl";
 
 dayjs.extend(duration);
 
+export function CurrentMatchLoading() {
+    return (
+        <div className="mb-6 border border-border rounded-lg bg-gradient-to-br from-primary/5 via-secondary/5 to-background p-6">
+            <div className="grid grid-cols-1 md:grid-cols-12 gap-6 items-center">
+                <div className="md:col-span-4">
+                    <Skeleton className="w-full h-40 rounded-lg" />
+                </div>
+                <div className="md:col-span-5">
+                    <Skeleton className="h-3 w-32 mb-3" />
+                    <Skeleton className="h-8 w-3/4 mb-3" />
+                    <Skeleton className="h-4 w-1/2 mb-4" />
+                    <Skeleton className="h-6 w-20 mb-4" />
+                    <div className="flex flex-row gap-2 flex-wrap">
+                        <Skeleton className="h-8 w-24" />
+                        <Skeleton className="h-8 w-24" />
+                        <Skeleton className="h-8 w-20" />
+                        <Skeleton className="h-8 w-20" />
+                    </div>
+                </div>
+                <div className="md:col-span-3">
+                    <div className="flex flex-col gap-4 items-center">
+                        <Skeleton className="h-12 w-16" />
+                        <Skeleton className="h-3 w-16" />
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
 export default function CurrentMatch({ serverPromise, mapCurrentPromise, playerContinentsPromise, userPromise }:
 { serverPromise: ServerSlugPromise, mapCurrentPromise: Promise<ServerMapMatch>, playerContinentsPromise: Promise<ContinentStatistics>, userPromise: Promise<SteamProfile | null> }
 ){

--- a/front-ze/components/maps/MapsTable.tsx
+++ b/front-ze/components/maps/MapsTable.tsx
@@ -54,6 +54,34 @@ const MapsRowSkeleton = () => {
     );
 }
 
+export function MapsTableSkeleton() {
+    const t = useTranslations('maps.table');
+    return (
+        <div className="border border-border rounded-lg bg-card overflow-hidden">
+            <Table>
+                <TableHeader>
+                    <TableRow>
+                        <TableHead className="font-bold">{t('map')}</TableHead>
+                        <TableHead className="font-bold">{t('status')}</TableHead>
+                        <TableHead align="right" className="font-bold text-right">{t('cumulativeHours')}</TableHead>
+                        <TableHead align="right" className="font-bold text-right">{t('hours')}</TableHead>
+                        <TableHead align="right" className="font-bold text-right">{t('players')}</TableHead>
+                        <TableHead align="right" className="font-bold text-right">{t('sessions')}</TableHead>
+                        <TableHead align="center" className="font-bold text-center">{t('lastPlayed')}</TableHead>
+                        <TableHead align="center" className="font-bold text-center"></TableHead>
+                        <TableHead align="center" className="font-bold text-center"></TableHead>
+                    </TableRow>
+                </TableHeader>
+                <TableBody>
+                    {Array.from({ length: 25 }).map((_, i) => (
+                        <MapsRowSkeleton key={i} />
+                    ))}
+                </TableBody>
+            </Table>
+        </div>
+    );
+}
+
 export const StatusChip = ({ map }) => {
     const t = useTranslations('maps.table');
     if (!map.enabled) return (


### PR DESCRIPTION
## Summary
- Fetch the initial page of the maps search index server-side (like `CurrentMatch`'s existing promises) and seed `MapsSearchIndex` state with it via `use()`, instead of relying purely on a client-side `useEffect` after mount.
- Skip the redundant first client-side fetch on mount (the server fetch already covers the default page/sort/filter), same pattern as `GlobalPlayerListDisplay`.
- Add `CurrentMatchLoading` and `MapsSearchIndexLoading` skeleton components and use them as the `Suspense` `fallback` for both sections on the maps page, replacing `fallback={null}` (which rendered nothing while pending).

## Test plan
- [x] `tsc --noEmit` shows no new errors introduced by these changes (pre-existing unrelated errors in other files remain).
- [ ] Load a server's `/maps` page and confirm no blank flash before `CurrentMatch`/the maps table appear.
- [ ] Confirm the maps table shows real data immediately on first paint (no extra client loading flicker).
- [ ] Confirm pagination/sort/filter/search interactions still refetch and show their existing in-place skeletons correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)