### PR TITLE
Resolve player promise before use(), enforce notFound/AccessDenied server-side

### DIFF
--- a/front-ze/app/servers/[server_slug]/players/[player_id]/ResolvePlayerInformation.tsx
+++ b/front-ze/app/servers/[server_slug]/players/[player_id]/ResolvePlayerInformation.tsx
@@ -1,6 +1,5 @@
-import {ServerPlayerDetailedWithError} from "./page.tsx";
+import {ServerPlayerDetailed} from "./page.tsx";
 import {use} from "react";
-import {notFound} from "next/navigation";
 import {StillCalculate} from "utils/generalUtils.ts";
 import PlayerCardDetail from "components/players/PlayerCardDetail.tsx";
 import PlayerSessionList from "components/players/PlayerSessionList.tsx";
@@ -9,20 +8,11 @@ import PlayerRegionPlayTime from "components/players/PlayerRegionPlayTime.tsx";
 import PlayerInfractionRecord from "components/players/PlayerInfractionRecord.tsx";
 import PlayerHourOfDay from "components/players/PlayerHourOfDay.tsx";
 import StillCalculatingPlayer from "./StillCalculatingPlayer.tsx";
-import AccessDenied from "./AccessDenied.tsx";
 
-export default function ResolvePlayerInformation({ serverPlayerPromise }: { serverPlayerPromise: Promise<ServerPlayerDetailedWithError> }) {
-    const { player, error } = use(serverPlayerPromise)
+export default function ResolvePlayerInformation({ serverPlayerPromise }: { serverPlayerPromise: Promise<ServerPlayerDetailed> }) {
+    const { player } = use(serverPlayerPromise)
 
-    if (error && error.code === 403) {
-        return <AccessDenied />;
-    }
-
-    if (error && error.code === 404) {
-        notFound();
-    }
-
-    if (player === null || player === undefined || player instanceof StillCalculate || !player.id) {
+    if (player instanceof StillCalculate) {
         return <StillCalculatingPlayer />;
     }
 

--- a/front-ze/app/servers/[server_slug]/players/[player_id]/page.tsx
+++ b/front-ze/app/servers/[server_slug]/players/[player_id]/page.tsx
@@ -18,6 +18,8 @@ import {Server} from "types/community.ts";
 import ResolvePlayerInformation from "./ResolvePlayerInformation.tsx";
 import {AdSpot} from "components/ui/AdSpot";
 import { getTranslations } from 'next-intl/server';
+import { notFound } from "next/navigation";
+import AccessDenied from "./AccessDenied.tsx";
 
 dayjs.extend(relativeTime);
 export async function generateMetadata({ params}: {
@@ -112,37 +114,27 @@ export type ServerPlayerDetailed = {
     server: Server,
     player: PlayerInfo | StillCalculate
 }
-export type ServerPlayerDetailedWithError = ServerPlayerDetailed & { error?: { code: number, message: string } }
 
 export default async function Page({ params }: { params: Promise<{ server_slug: string, player_id: string }>}){
     const { server_slug, player_id } = await params;
 
     const server = await getServerSlugOrNotFound(server_slug);
 
-    const serverPlayerPromise = (async () => {
-        try {
-            const player = await getPlayerDetailed(server.id, player_id, "return")
-            return {player, server} as ServerPlayerDetailedWithError
-        } catch (error: any) {
-            return {
-                player: null,
-                server,
-                error: {
-                    code: error?.code || 500,
-                    message: error?.message || "An error occurred"
-                }
-            } as ServerPlayerDetailedWithError
-        }
-    })()
+    let player: PlayerInfo | StillCalculate
+    try {
+        player = await getPlayerDetailed(server.id, player_id, "return")
+    } catch (error: any) {
+        if (error?.code === 404) notFound()
+        if (error?.code === 403) return <AccessDenied />
+        throw error
+    }
+
+    const serverPlayer: ServerPlayerDetailed = { server, player }
 
     // Generate JSON-LD structured data for SEO
-    const serverPlayer = await serverPlayerPromise;
     let jsonLd = null;
 
-    if (serverPlayer.player && !('code' in serverPlayer.player)) {
-        const player = serverPlayer.player;
-        const server = serverPlayer.server;
-
+    if (!(player instanceof StillCalculate)) {
         jsonLd = {
             "@context": "https://schema.org",
             "@type": "Person",
@@ -175,7 +167,7 @@ export default async function Page({ params }: { params: Promise<{ server_slug: 
             )}
             <div className="p-4">
                 <AdSpot className="mb-4" />
-                <ResolvePlayerInformation serverPlayerPromise={serverPlayerPromise} />
+                <ResolvePlayerInformation serverPlayerPromise={Promise.resolve(serverPlayer)} />
             </div>
         </>
     );


### PR DESCRIPTION
## Summary
- `serverPlayerPromise` now resolves to a plain `ServerPlayerDetailed` (`{server, player}`) instead of the `ServerPlayerDetailedWithError` wrapper.
- 404/403 are handled via try/catch around `getPlayerDetailed` directly in `page.tsx` (Server Component), matching the existing pattern in `sessions/[session_id]/page.tsx`, `maps/[map_name]/page.tsx`, and `characters/[character_model_id]/page.tsx` — 404 calls `notFound()`, 403 renders `<AccessDenied />` inline, everything else rethrows.
- `ResolvePlayerInformation.tsx` now just `use()`s the promise and checks `player instanceof StillCalculate` — no more error-code branching or `notFound()` call inside the component.
- Downstream consumers (`PlayerCardDetail`, `PlayerSessionList`, `PlayerTopMap`, `PlayerRegionPlayTime`, `PlayerInfractionRecord`, `PlayerHourOfDay`) already typed their prop as `Promise<ServerPlayerDetailed>` and never touched `error` — no changes needed there, they now get the value type they always claimed.

## Test plan
- [x] `tsc --noEmit` on the touched files and their consumers shows no new errors (pre-existing, unrelated errors elsewhere in the repo untouched).
- [ ] Manually verify in dev: valid player renders grid, invalid player 404s, 403 shows AccessDenied, still-calculating player shows StillCalculatingPlayer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)