### PR TITLE
Stream map-session page via use() instead of blocking await

### DIFF
--- a/front-ze/app/servers/[server_slug]/maps/[map_name]/sessions/[session_id]/MapSessionWrapper.tsx
+++ b/front-ze/app/servers/[server_slug]/maps/[map_name]/sessions/[session_id]/MapSessionWrapper.tsx
@@ -5,13 +5,37 @@ import { ServerPopChart } from "components/sessions/ServerPopChart.tsx";
 import MapMatchScoreChart from "components/sessions/MapMatchScoreChart.tsx";
 import SessionContinents from "components/sessions/SessionContinents.tsx";
 import MutualSessionsDisplay from "components/sessions/MutualSessionsDisplay.tsx";
-import { use, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import getSessionData, { SessionData } from "./utils.ts";
 import {AdSpot} from "components/ui/AdSpot";
+import {Skeleton} from "components/ui/skeleton";
 
-export default function MapSessionWrapper({ sessionPromise }: { sessionPromise: Promise<SessionData> }) {
-    const serverData = use(sessionPromise)
-    const [data, setData] = useState<SessionData>(serverData)
+export function MapSessionWrapperLoading() {
+    return (
+        <div className="min-h-screen p-4 md:p-6 lg:p-8">
+            <Skeleton className="rounded-lg h-40 w-full" />
+
+            <div className="my-4">
+                <Skeleton className="rounded-lg h-24 w-full" />
+            </div>
+
+            <div className="grid grid-cols-1 lg:grid-cols-12 gap-4 md:gap-6">
+                <div className="lg:col-span-7 xl:col-span-8 space-y-6">
+                    <Skeleton className="rounded-lg h-64 w-full" />
+                    <Skeleton className="rounded-lg h-96 w-full" />
+                    <Skeleton className="rounded-lg h-96 w-full" />
+                </div>
+
+                <div className="lg:col-span-5 xl:col-span-4">
+                    <Skeleton className="rounded-lg h-[600px] w-full" />
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default function MapSessionWrapper({ initialData }: { initialData: SessionData }) {
+    const [data, setData] = useState<SessionData>(initialData)
 
     useEffect(() => {
         if (data.sessionInfo.ended_at !== null) return

--- a/front-ze/app/servers/[server_slug]/maps/[map_name]/sessions/[session_id]/ResolveMapSession.tsx
+++ b/front-ze/app/servers/[server_slug]/maps/[map_name]/sessions/[session_id]/ResolveMapSession.tsx
@@ -1,0 +1,16 @@
+import { use } from "react";
+import { notFound } from "next/navigation";
+import MapSessionWrapper from "./MapSessionWrapper.tsx";
+import type { SessionData } from "./utils.ts";
+
+export default function ResolveMapSession({ sessionPromise }: { sessionPromise: Promise<SessionData> }) {
+    let data: SessionData;
+    try {
+        data = use(sessionPromise);
+    } catch (err: any) {
+        if (err && typeof err.then === "function") throw err;
+        if (err?.code === 404 || err?.code === 400) notFound();
+        throw err;
+    }
+    return <MapSessionWrapper initialData={data} />;
+}

--- a/front-ze/app/servers/[server_slug]/maps/[map_name]/sessions/[session_id]/page.tsx
+++ b/front-ze/app/servers/[server_slug]/maps/[map_name]/sessions/[session_id]/page.tsx
@@ -11,10 +11,11 @@ import {Metadata} from "next";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import timezone from "dayjs/plugin/timezone";
-import MapSessionWrapper from "./MapSessionWrapper.tsx";
+import {Suspense} from "react";
+import ResolveMapSession from "./ResolveMapSession.tsx";
+import {MapSessionWrapperLoading} from "./MapSessionWrapper.tsx";
 import getSessionData from "./utils.ts";
 import { getTranslations } from 'next-intl/server';
-import { notFound } from 'next/navigation';
 
 dayjs.extend(relativeTime);
 dayjs.extend(timezone)
@@ -105,13 +106,11 @@ export default async function Page({ params }) {
     const { session_id, server_slug, map_name } = await params;
     const server = await getServerSlugOrNotFound(server_slug);
 
-    let sessionData
-    try{
-        sessionData = await getSessionData(server, map_name, session_id)
-    }catch(error: any){
-        if (error?.code === 404 || error?.code === 400) notFound()
-        throw error
-    }
+    const sessionDataPromise = getSessionData(server, map_name, session_id);
 
-    return <MapSessionWrapper sessionPromise={Promise.resolve(sessionData)} />
+    return (
+        <Suspense fallback={<MapSessionWrapperLoading />}>
+            <ResolveMapSession sessionPromise={sessionDataPromise} />
+        </Suspense>
+    );
 }


### PR DESCRIPTION
## Summary
- `maps/[map_name]/sessions/[session_id]/page.tsx` no longer awaits `getSessionData` (a fan-out of 6 API calls) before returning — the unresolved promise is now streamed down and wrapped in `<Suspense>`.
- New `ResolveMapSession.tsx` (server-only, no `'use client'`) resolves the promise via `use()` and calls `notFound()` for 404/400, mirroring the existing `ResolvePlayerInformation.tsx` pattern — this keeps `notFound()` reliable without letting a rejected promise cross the server/client boundary (a documented gotcha called out in the sibling player-sessions page).
- `MapSessionWrapper.tsx` now takes plain `initialData` instead of consuming the promise itself, and exports a new `MapSessionWrapperLoading` skeleton used as the Suspense fallback.

## Test plan
- [x] `tsc --noEmit` on the touched files shows no new errors (40 pre-existing, unrelated errors remain elsewhere in the repo)
- [ ] `npm run dev`, visit a valid map session URL and confirm it renders
- [ ] Visit an invalid session id and confirm `not-found.tsx` ("Session Not Found") still renders
- [ ] Confirm the 65s live-refresh for an in-progress session still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)