### PR TITLE
Seed FetchStatusTable via use() instead of client-only fetch

### DIFF
--- a/front-ze/app/status/page.tsx
+++ b/front-ze/app/status/page.tsx
@@ -1,9 +1,10 @@
+import { Suspense } from "react";
 import ResponsiveAppBar from "components/ui/ResponsiveAppBar";
 import Footer from "components/ui/Footer";
 import getServerUser from "app/getServerUser";
-import FetchStatusTable from "components/status/FetchStatusTable";
+import FetchStatusTable, { FetchStatusTableLoading } from "components/status/FetchStatusTable";
 import { Metadata } from "next";
-import {formatTitle} from "utils/generalUtils.ts";
+import {fetchUrl, formatTitle} from "utils/generalUtils.ts";
 import { getTranslations } from 'next-intl/server';
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -20,6 +21,7 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function StatusPage() {
     const t = await getTranslations('status');
     const user = getServerUser();
+    const statusPromise = fetchUrl("/fetch-status-truncated", { next: { revalidate: 60 } });
 
     return <>
         <ResponsiveAppBar userPromise={user} server={null} setDisplayCommunity={null} />
@@ -34,7 +36,9 @@ export default async function StatusPage() {
                             {t('subtitle')}
                         </p>
                     </div>
-                    <FetchStatusTable />
+                    <Suspense fallback={<FetchStatusTableLoading />}>
+                        <FetchStatusTable initialDataPromise={statusPromise} />
+                    </Suspense>
                 </div>
             </div>
         </div>

--- a/front-ze/components/status/FetchStatusTable.tsx
+++ b/front-ze/components/status/FetchStatusTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { use, useEffect, useState, useCallback } from "react";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import { Badge } from "components/ui/badge";
@@ -19,6 +19,7 @@ import {
 } from "types/fetchStatus";
 import {fetchUrl} from "utils/generalUtils.ts";
 import { useTranslations } from 'next-intl';
+import ErrorCatch from "components/ui/ErrorMessage.tsx";
 
 dayjs.extend(relativeTime);
 
@@ -194,7 +195,7 @@ function ServerStatusCard({ group }: { group: FetchStatusServerGroupTruncated })
     );
 }
 
-function StatusSkeleton() {
+export function FetchStatusTableLoading() {
     return (
         <div className="flex flex-col gap-4">
             <Skeleton className="h-14 w-full rounded-xl" />
@@ -222,10 +223,11 @@ function StatusSkeleton() {
     );
 }
 
-export default function FetchStatusTable() {
+function FetchStatusTableDisplay({ initialDataPromise }: { initialDataPromise: Promise<FetchStatusCommunityGroupTruncated[]> }) {
     const t = useTranslations('status.table');
-    const [entries, setEntries] = useState<FetchStatusCommunityGroupTruncated[] | null>(null);
-    const [lastUpdated, setLastUpdated] = useState<dayjs.Dayjs | null>(null);
+    const initialData = use(initialDataPromise);
+    const [entries, setEntries] = useState<FetchStatusCommunityGroupTruncated[]>(initialData || []);
+    const [lastUpdated, setLastUpdated] = useState<dayjs.Dayjs | null>(initialData ? dayjs() : null);
 
     const fetchData = useCallback(async () => {
         try {
@@ -236,12 +238,9 @@ export default function FetchStatusTable() {
     }, []);
 
     useEffect(() => {
-        fetchData();
         const id = setInterval(fetchData, POLL_INTERVAL);
         return () => clearInterval(id);
     }, [fetchData]);
-
-    if (entries === null) return <StatusSkeleton />;
 
     const communities = entries;
     const overallStatus = computeOverallStatus(communities);
@@ -293,5 +292,13 @@ export default function FetchStatusTable() {
                 </>
             )}
         </div>
+    );
+}
+
+export default function FetchStatusTable({ initialDataPromise }: { initialDataPromise: Promise<FetchStatusCommunityGroupTruncated[]> }) {
+    return (
+        <ErrorCatch message="Fetch status couldn't be loaded.">
+            <FetchStatusTableDisplay initialDataPromise={initialDataPromise} />
+        </ErrorCatch>
     );
 }


### PR DESCRIPTION
## Summary
- `FetchStatusTable` was the last polling component still fetching entirely client-side on mount; every sibling component (`GlobalPlayerList`, `PlayersOnline`, `PlayerByCountries`, etc.) already fetches server-side and streams the promise down via `use()` + `Suspense`.
- `app/status/page.tsx` now kicks off `/fetch-status-truncated` server-side and passes it as `initialDataPromise`; `FetchStatusTable` seeds its state via `use()` instead of an internal `entries === null` skeleton branch.
- Renamed the internal skeleton to an exported `FetchStatusTableLoading` for the `Suspense` fallback, and wrapped the default export in `ErrorCatch` to match `PlayersOnline`'s error-boundary pattern.
- The polling `setInterval` no longer fires an immediate fetch on mount (data is already seeded) — same shape as `GlobalPlayersOnline`, which has the identical "seed once + interval" effect.

## Test plan
- [x] `tsc --noEmit` shows no new errors introduced by these two files (pre-existing unrelated errors elsewhere in the repo are untouched)
- [ ] Load `/status` in a browser: data renders immediately with no skeleton flash, "Updated …" timestamp populated right away, table still polls every 10s
- [ ] Break the endpoint temporarily to confirm `ErrorCatch` renders its fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)