### PR TITLE
Fetch profile heatmap server-side and unwrap via use()

### DIFF
--- a/front-ze/app/users/[user_id]/profile/page.tsx
+++ b/front-ze/app/users/[user_id]/profile/page.tsx
@@ -4,7 +4,7 @@ import ProfileOverview from "components/users/ProfileOverview";
 import ProfileStatsCards from "components/users/ProfileStatsCards";
 import getServerUser from "../../../getServerUser";
 import { redirect } from "next/navigation";
-import { ProfileResponse } from "types/community.ts";
+import { PlayerSessionTime, ProfileResponse } from "types/community.ts";
 import {
     fetchApiUrl,
     fetchUrl,
@@ -109,13 +109,14 @@ export default async function Page({ params }: { params: Promise<{ user_id: stri
 
     const sessionUserPromise = getServerUser();
     const profilePromise: Promise<ProfileResponse> = fetchApiUrl(`/accounts/${user_id}/profile`);
+    const heatmapPromise: Promise<PlayerSessionTime[]> = fetchApiUrl(`/accounts/${user_id}/playtime-heatmap`).catch(() => []);
 
     return (<>
         <ResponsiveAppBar userPromise={sessionUserPromise} server={null} setDisplayCommunity={null} />
         <div className="container mx-auto max-w-7xl px-4 py-8">
             <div className="flex flex-col gap-6">
                 <UserProfile profilePromise={profilePromise} />
-                <ProfileOverview userId={user_id} />
+                <ProfileOverview heatmapPromise={heatmapPromise} />
                 <ProfileStatsCards userId={user_id} profilePromise={profilePromise} />
                 <UserCommunityConnections profilePromise={profilePromise} />
             </div>

--- a/front-ze/components/users/ProfileHeatmap.tsx
+++ b/front-ze/components/users/ProfileHeatmap.tsx
@@ -9,8 +9,8 @@ import isoWeek from "dayjs/plugin/isoWeek";
 import utc from "dayjs/plugin/utc";
 import { useTranslations } from "next-intl";
 import { useTheme } from "next-themes";
-import { fetchApiUrl, formatNumber } from "utils/generalUtils";
-import { Skeleton } from "components/ui/skeleton";
+import { formatNumber } from "utils/generalUtils";
+import { PlayerSessionTime } from "types/community";
 import { ScrollArea, ScrollBar } from "components/ui/scroll-area";
 import { ScreenReaderOnly } from "components/ui/ScreenReaderOnly";
 import { LazyMatrixChart } from "components/graphs/LazyCharts";
@@ -34,11 +34,6 @@ const ROWS = 7
 const CHART_WIDTH = '1025px'
 const Y_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 
-type PlayerSessionTime = {
-    bucket_time: string,
-    hours: number,
-}
-
 type HeatmapData = {
     x: string,
     y: string,
@@ -55,19 +50,9 @@ function getChartColors(isDark: boolean) {
     };
 }
 
-export default function ProfileHeatmap({ userId }: { userId: string }) {
+export default function ProfileHeatmap({ rawData }: { rawData: PlayerSessionTime[] }) {
     const t = useTranslations('players.heatmap')
-    const [loading, setLoading] = useState(true);
-    const [rawData, setRawData] = useState<PlayerSessionTime[]>([]);
     const [selectedYear, setSelectedYear] = useState<number>(dayjs().year());
-
-    useEffect(() => {
-        setLoading(true);
-        fetchApiUrl(`/accounts/${userId}/playtime-heatmap`)
-            .then(setRawData)
-            .catch(() => setRawData([]))
-            .finally(() => setLoading(false));
-    }, [userId]);
 
     const availableYears = useMemo(() => {
         const years = [...new Set(rawData.map(d => dayjs.utc(d.bucket_time).year()))]
@@ -231,10 +216,6 @@ export default function ProfileHeatmap({ userId }: { userId: string }) {
             peak: formatNumber(maxHours),
         });
     }, [heatmapData, totalHours, maxHours, t]);
-
-    if (loading) {
-        return <Skeleton className="h-40 w-full" />;
-    }
 
     return (
         <div>

--- a/front-ze/components/users/ProfileOverview.tsx
+++ b/front-ze/components/users/ProfileOverview.tsx
@@ -1,13 +1,16 @@
 'use client';
 
+import { use } from "react";
 import { Card, CardContent } from "components/ui/card";
+import { PlayerSessionTime } from "types/community";
 import ProfileHeatmap from "./ProfileHeatmap";
 
-export default function ProfileOverview({ userId }: { userId: string }) {
+export default function ProfileOverview({ heatmapPromise }: { heatmapPromise: Promise<PlayerSessionTime[]> }) {
+    const rawData = use(heatmapPromise);
     return (
         <Card className="border-border/40 bg-card/50 backdrop-blur-xl">
             <CardContent className="p-6">
-                <ProfileHeatmap userId={userId} />
+                <ProfileHeatmap rawData={rawData} />
             </CardContent>
         </Card>
     );

--- a/front-ze/types/community.ts
+++ b/front-ze/types/community.ts
@@ -118,3 +118,8 @@ export interface ProfileResponse {
     is_owner: boolean;
     anonymization: UserAnonymization[] | null;
 }
+
+export interface PlayerSessionTime {
+    bucket_time: string;
+    hours: number;
+}


### PR DESCRIPTION
## Summary
- ProfileHeatmap fetched `/accounts/{userId}/playtime-heatmap` itself in a client `useEffect`, causing a loading flicker and a fetch-after-hydration waterfall, unlike the sibling profile sections which already stream a server-created promise consumed via React's `use()`.
- `page.tsx` now creates `heatmapPromise` alongside `profilePromise` (in parallel, not awaited), passes it to `ProfileOverview`, which unwraps it with `use()` and passes the resolved array down to `ProfileHeatmap` as a plain prop.
- `PlayerSessionTime` moved from `ProfileHeatmap.tsx` to `types/community.ts` so it can be shared between the server page and client components.

## Test plan
- [x] `tsc --noEmit` shows no new errors introduced by these files (remaining errors are pre-existing, unrelated to this change)
- [ ] Load a user profile page with playtime history and confirm the heatmap renders with data and the year selector works
- [ ] Load a profile with no heatmap data and confirm the empty state still renders instead of an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)